### PR TITLE
Fix f-string for CriminalIP report link

### DIFF
--- a/leanscan.py
+++ b/leanscan.py
@@ -501,7 +501,7 @@ for indicator in indicators:
             "easydmarc": f"https://easydmarc.com/tools/ip-domain-reputation-check?term={indicator}",
             "scamalytics": f"https://scamalytics.com/ip/{indicator}",
             "shadowserver": f"N/A",
-            "criminalip": "https://www.criminalip.io/asset/report/{indicator}"
+            "criminalip": f"https://www.criminalip.io/asset/report/{indicator}"
         }
 
 


### PR DESCRIPTION
## Summary
- fix interpolation for CriminalIP links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411ef82fe0832787c841cd5708d492